### PR TITLE
IONotifications instead of endless loop

### DIFF
--- a/USBNotifier/Resources/Localizable.xcstrings
+++ b/USBNotifier/Resources/Localizable.xcstrings
@@ -131,16 +131,6 @@
         }
       }
     },
-    "usb.service.delay" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polling Interval"
-          }
-        }
-      }
-    },
     "usb.service.ephemeral" : {
       "localizations" : {
         "en" : {

--- a/USBNotifier/Values/Storage.swift
+++ b/USBNotifier/Values/Storage.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct Storage {
     static var shared = Storage()
 
-    @AppStorage("detectionDelay") var detectionDelay = 1
     @AppStorage("connectionSound") var connectionSound = false
     @AppStorage("ephemeralNotifs") var ephemeralNotifs = false
 }
@@ -19,13 +18,6 @@ struct Storage {
 extension Storage {
     final class Observable: ObservableObject {
 
-        var detectionDelay: Int {
-            get { Storage.shared.detectionDelay }
-            set {
-                Storage.shared.detectionDelay = newValue
-                objectWillChange.send()
-            }
-        }
         var connectionSound: Bool {
             get { Storage.shared.connectionSound }
             set {

--- a/USBNotifier/Views/MenuBarView.swift
+++ b/USBNotifier/Views/MenuBarView.swift
@@ -35,12 +35,6 @@ struct MenuBarView: View {
             Divider()
 
             Menu {
-                Picker("usb.service.delay", selection: $storage.detectionDelay) {
-                    ForEach(possibleDetectionDelays, id: \.self) { delay in
-                        Text("\(delay) second" + (delay == 1 ? "" : String(localized: "plural.ext"))).tag(delay)
-                    }
-                }
-
                 Toggle(isOn: $storage.connectionSound) {
                     Text("usb.service.makeSound")
                 }


### PR DESCRIPTION
Hey, I found your app on reddit, had a look at the code and found the `while(true)` loop. I thought this can probably be improved and checked out the documentation. There is an API to register a callback whenever new devices are added or removed. In this PR, I added this API to your app.

I added a timer to throttle the incoming devices by collecting them and only showing the notification if no devices were added/removed for 1 second.